### PR TITLE
Fetch queue items explicitly and harden queue handling

### DIFF
--- a/src/components/MaQueue/MaQueue.tsx
+++ b/src/components/MaQueue/MaQueue.tsx
@@ -27,7 +27,7 @@ export const MaQueue = ({
     return <Spinner />;
   }
 
-  if (!queue || queue.items.length === 0) {
+  if (!queue || queue.items?.length === 0) {
     return <p css={searchStyles.mediaEmptyText}>Queue is empty</p>;
   }
 
@@ -37,7 +37,7 @@ export const MaQueue = ({
       style={{ maxHeight }}
     >
       <div css={searchStyles.resultsContainerSearchBarBottom}>
-        {queue.items.map(item => (
+        {(queue.items ?? []).map(item => (
           <MediaTrack
             key={item.queue_item_id}
             imageUrl={item.media_item.image ?? item.media_item.album?.image}

--- a/src/components/MaQueue/types.ts
+++ b/src/components/MaQueue/types.ts
@@ -10,6 +10,9 @@ export interface MaQueueItem {
 }
 
 export interface MaQueueResponse {
-  items: MaQueueItem[];
+  queue_id: string;
+  current_item: MaQueueItem | null;
+  next_item: MaQueueItem | null;
+  items?: MaQueueItem[];
 }
 

--- a/src/components/MaQueue/useQueue.ts
+++ b/src/components/MaQueue/useQueue.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "preact/hooks";
 import { getHass } from "@utils";
-import { MaQueueResponse } from "./types";
+import { MaQueueItem, MaQueueResponse } from "./types";
 
 export const useQueue = (entityId: string) => {
   const [queue, setQueue] = useState<MaQueueResponse | null>(null);
@@ -11,22 +11,54 @@ export const useQueue = (entityId: string) => {
 
     const fetchQueue = async () => {
       setLoading(true);
-      const message = {
-        type: "call_service",
-        domain: "music_assistant",
-        service: "get_queue",
-        target: { entity_id: entityId },
-        service_data: {},
-        return_response: true,
-      };
 
       const hass = getHass();
       try {
+        const message = {
+          type: "call_service",
+          domain: "music_assistant",
+          service: "get_queue",
+          service_data: { entity_id: entityId },
+          return_response: true,
+        };
+
         const res = await hass.connection.sendMessagePromise(message);
-        const response = res as { response: MaQueueResponse };
-        if (response.response) {
-          setQueue(response.response);
+        const response = res as {
+          response: { [key: string]: Omit<MaQueueResponse, "items"> };
+        };
+        const queueResponse = response.response?.[entityId];
+        if (!queueResponse) return;
+
+        const { queue_id } = queueResponse;
+        let items: MaQueueItem[] = [];
+
+        try {
+          const itemsMessage = {
+            type: "call_service",
+            domain: "music_assistant",
+            service: "get_queue_items",
+            service_data: {
+              queue_id,
+              limit: 1000,
+            },
+            return_response: true,
+          };
+          const itemsRes = await hass.connection.sendMessagePromise(itemsMessage);
+          const itemsResponse = itemsRes as {
+            response: Record<string, unknown>;
+          };
+          items =
+            (itemsResponse.response?.items as MaQueueItem[] | undefined) ??
+            (
+              (itemsResponse.response?.[queue_id] as { items?: MaQueueItem[] } | undefined)
+                ?.items
+            ) ??
+            [];
+        } catch (e) {
+          console.error("Error fetching queue items:", e);
         }
+
+        setQueue({ ...queueResponse, items });
       } catch (e) {
         console.error("Error fetching queue:", e);
       } finally {


### PR DESCRIPTION
## Summary
- Fetch full queue metadata and items by calling `get_queue_items` after `get_queue`
- Extend queue types with `queue_id`, `current_item`, `next_item`, and optional `items`
- Guard queue rendering with optional chaining to avoid crashes on empty/undefined lists
- Parse Music Assistant responses keyed by entity and queue IDs to populate items correctly

## Testing
- `yarn lint`
- `yarn test`
- `yarn tsc`


------
https://chatgpt.com/codex/tasks/task_e_68a6b14fa9648321b3d0cd7cb1c87af8