### PR TITLE
feat: use mass queue service for playback queue

### DIFF
--- a/src/components/MaQueue/MaQueue.tsx
+++ b/src/components/MaQueue/MaQueue.tsx
@@ -27,7 +27,7 @@ export const MaQueue = ({
     return <Spinner />;
   }
 
-  if (!queue || queue.items?.length === 0) {
+  if (queue.length === 0) {
     return <p css={searchStyles.mediaEmptyText}>Queue is empty</p>;
   }
 
@@ -37,14 +37,12 @@ export const MaQueue = ({
       style={{ maxHeight }}
     >
       <div css={searchStyles.resultsContainerSearchBarBottom}>
-        {(queue.items ?? []).map(item => (
+        {queue.map(item => (
           <MediaTrack
             key={item.queue_item_id}
-            imageUrl={item.media_item.image ?? item.media_item.album?.image}
-            title={item.media_item.name}
-            artist={item.media_item.artists
-              ?.map(artist => artist.name)
-              .join(", ")}
+            imageUrl={item.media_image}
+            title={item.media_title}
+            artist={item.media_artist}
             onClick={async () => {}}
           />
         ))}

--- a/src/components/MaQueue/types.ts
+++ b/src/components/MaQueue/types.ts
@@ -1,18 +1,11 @@
 export interface MaQueueItem {
   queue_item_id: string;
-  name: string;
-  media_item: {
-    name: string;
-    image?: string | null;
-    album?: { image?: string | null };
-    artists?: { name: string }[];
-  };
+  media_title: string;
+  media_album_name?: string;
+  media_artist?: string;
+  media_content_id?: string;
+  media_image?: string;
 }
 
-export interface MaQueueResponse {
-  queue_id: string;
-  current_item: MaQueueItem | null;
-  next_item: MaQueueItem | null;
-  items?: MaQueueItem[];
-}
+export type MaQueueResponse = MaQueueItem[];
 


### PR DESCRIPTION
## Summary
- replace deprecated music_assistant queue calls with mass_queue.get_queue_items
- guard against missing mass_queue service
- render queue items using new response shape

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68a6bab92cb4832189c6ac9218618f4d