### PR TITLE
feat: add queue item management

### DIFF
--- a/src/components/MaQueue/MaQueue.tsx
+++ b/src/components/MaQueue/MaQueue.tsx
@@ -1,6 +1,6 @@
 import { css } from "@emotion/react";
 import { searchStyles } from "@components/MediaSearch";
-import { MediaTrack, Spinner } from "@components";
+import { IconButton, MediaTrack, Spinner } from "@components";
 import { useQueue } from "./useQueue";
 
 export type MaQueueProps = {
@@ -14,6 +14,10 @@ const styles = {
     css({
       "--mmpc-search-padding": `${horizontalPadding}px`,
     }),
+  actions: css({
+    display: "flex",
+    gap: 4,
+  }),
 };
 
 export const MaQueue = ({
@@ -21,7 +25,15 @@ export const MaQueue = ({
   horizontalPadding = 0,
   maxHeight = 300,
 }: MaQueueProps) => {
-  const { queue, loading } = useQueue(entityId);
+  const {
+    queue,
+    loading,
+    removeQueueItem,
+    playQueueItem,
+    moveQueueItemUp,
+    moveQueueItemDown,
+    moveQueueItemNext,
+  } = useQueue(entityId);
 
   if (loading) {
     return <Spinner />;
@@ -43,11 +55,53 @@ export const MaQueue = ({
             imageUrl={item.media_image}
             title={item.media_title}
             artist={item.media_artist}
-            onClick={async () => {}}
+            actions={
+              <div css={styles.actions}>
+                <IconButton
+                  size="xx-small"
+                  icon="mdi:play"
+                  onClick={async e => {
+                    e.stopPropagation();
+                    await playQueueItem(item.queue_item_id);
+                  }}
+                />
+                <IconButton
+                  size="xx-small"
+                  icon="mdi:arrow-up"
+                  onClick={async e => {
+                    e.stopPropagation();
+                    await moveQueueItemUp(item.queue_item_id);
+                  }}
+                />
+                <IconButton
+                  size="xx-small"
+                  icon="mdi:arrow-down"
+                  onClick={async e => {
+                    e.stopPropagation();
+                    await moveQueueItemDown(item.queue_item_id);
+                  }}
+                />
+                <IconButton
+                  size="xx-small"
+                  icon="mdi:skip-next"
+                  onClick={async e => {
+                    e.stopPropagation();
+                    await moveQueueItemNext(item.queue_item_id);
+                  }}
+                />
+                <IconButton
+                  size="xx-small"
+                  icon="mdi:close"
+                  onClick={async e => {
+                    e.stopPropagation();
+                    await removeQueueItem(item.queue_item_id);
+                  }}
+                />
+              </div>
+            }
           />
         ))}
       </div>
     </div>
   );
 };
-

--- a/src/components/MaQueue/useQueue.ts
+++ b/src/components/MaQueue/useQueue.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "preact/hooks";
+import { useCallback, useEffect, useMemo, useState } from "preact/hooks";
 import { getHass } from "@utils";
 import { MaQueueItem, MaQueueResponse } from "./types";
 
@@ -6,42 +6,96 @@ export const useQueue = (entityId: string) => {
   const [queue, setQueue] = useState<MaQueueResponse>([]);
   const [loading, setLoading] = useState(false);
 
-  useEffect(() => {
+  const fetchQueue = useCallback(async () => {
     if (!entityId) return;
+    setLoading(true);
 
-    const fetchQueue = async () => {
-      setLoading(true);
-
-      const hass = getHass();
-      try {
-        if (!hass.services?.mass_queue?.get_queue_items) {
-          throw new Error("Service mass_queue.get_queue_items not found");
-        }
-
-        const message = {
-          type: "call_service",
-          domain: "mass_queue",
-          service: "get_queue_items",
-          service_data: {
-            entity: entityId,
-          },
-          return_response: true,
-        };
-
-        const res = await hass.connection.sendMessagePromise(message);
-        const response = res as { response: Record<string, MaQueueItem[]> };
-        const items = response.response?.[entityId] ?? [];
-        setQueue(items);
-      } catch (e) {
-        console.error("Error fetching queue items:", e);
-      } finally {
-        setLoading(false);
+    const hass = getHass();
+    try {
+      if (!hass.services?.mass_queue?.get_queue_items) {
+        throw new Error("Service mass_queue.get_queue_items not found");
       }
-    };
 
-    fetchQueue();
+      const message = {
+        type: "call_service",
+        domain: "mass_queue",
+        service: "get_queue_items",
+        service_data: {
+          entity: entityId,
+        },
+        return_response: true,
+      };
+
+      const res = await hass.connection.sendMessagePromise(message);
+      const response = res as { response: Record<string, MaQueueItem[]> };
+      const items = response.response?.[entityId] ?? [];
+      setQueue(items);
+    } catch (e) {
+      console.error("Error fetching queue items:", e);
+    } finally {
+      setLoading(false);
+    }
   }, [entityId]);
 
-  return useMemo(() => ({ queue, loading }), [queue, loading]);
-};
+  useEffect(() => {
+    fetchQueue();
+  }, [fetchQueue]);
 
+  const callService = useCallback(
+    async (service: string, queueItemId: string) => {
+      const hass = getHass();
+      try {
+        await hass.callService("mass_queue", service, {
+          entity: entityId,
+          queue_item_id: queueItemId,
+        });
+        await fetchQueue();
+      } catch (e) {
+        console.error(`Error calling ${service}:`, e);
+      }
+    },
+    [entityId, fetchQueue]
+  );
+
+  const removeQueueItem = useCallback(
+    async (id: string) => callService("remove_queue_item", id),
+    [callService]
+  );
+  const playQueueItem = useCallback(
+    async (id: string) => callService("play_queue_item", id),
+    [callService]
+  );
+  const moveQueueItemUp = useCallback(
+    async (id: string) => callService("move_queue_item_up", id),
+    [callService]
+  );
+  const moveQueueItemDown = useCallback(
+    async (id: string) => callService("move_queue_item_down", id),
+    [callService]
+  );
+  const moveQueueItemNext = useCallback(
+    async (id: string) => callService("move_queue_item_next", id),
+    [callService]
+  );
+
+  return useMemo(
+    () => ({
+      queue,
+      loading,
+      removeQueueItem,
+      playQueueItem,
+      moveQueueItemUp,
+      moveQueueItemDown,
+      moveQueueItemNext,
+    }),
+    [
+      queue,
+      loading,
+      removeQueueItem,
+      playQueueItem,
+      moveQueueItemUp,
+      moveQueueItemDown,
+      moveQueueItemNext,
+    ]
+  );
+};

--- a/src/components/MediaSearch/components/MediaTrack.tsx
+++ b/src/components/MediaSearch/components/MediaTrack.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useState } from "preact/hooks";
+import { JSX } from "preact/compat";
 import { MediaImage } from "./MediaImage";
 import { css } from "@emotion/react";
 
@@ -47,13 +48,22 @@ const styles = {
     width: 50,
     height: 50,
   }),
+  rootNotClickable: css({
+    cursor: "default",
+  }),
+  actions: css({
+    display: "flex",
+    gap: 4,
+    alignItems: "center",
+  }),
 };
 
 export type MediaTrackProps = {
   imageUrl?: string | null;
   title: string;
   artist?: string;
-  onClick: () => Promise<void>;
+  onClick?: () => Promise<void>;
+  actions?: JSX.Element;
 };
 
 export const MediaTrack = ({
@@ -61,10 +71,12 @@ export const MediaTrack = ({
   title,
   artist,
   onClick,
+  actions,
 }: MediaTrackProps) => {
   const [loading, setLoading] = useState(false);
   const [done, setDone] = useState(false);
   const handleOnClick = useCallback(async () => {
+    if (!onClick) return;
     setDone(false);
     setLoading(true);
     try {
@@ -77,7 +89,10 @@ export const MediaTrack = ({
   }, [onClick]);
 
   return (
-    <div css={styles.root} onClick={handleOnClick}>
+    <div
+      css={[styles.root, !onClick && styles.rootNotClickable]}
+      onClick={onClick ? handleOnClick : undefined}
+    >
       <MediaImage
         css={styles.mediaImage}
         imageUrl={imageUrl}
@@ -88,6 +103,7 @@ export const MediaTrack = ({
         <div css={styles.trackName}>{title}</div>
         {!!artist && <div css={styles.trackArtist}>{artist}</div>}
       </div>
+      {actions && <div css={styles.actions}>{actions}</div>}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- show buttons to play, remove, and move queue items
- extend MediaTrack to support action buttons
- add mass queue service calls and refresh queue after operations

## Testing
- `yarn lint src/components/MaQueue/MaQueue.tsx src/components/MaQueue/useQueue.ts src/components/MediaSearch/components/MediaTrack.tsx`
- `yarn tsc`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68a6c66c51808321bfe8afb2520379d5