### PR TITLE
docs: document mass_queue requirement for queue feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # 🎵 Mediocre Media Player Cards
+
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://github.com/custom-components/hacs)
 [![GitHub Release](https://img.shields.io/github/v/release/antontanderup/mediocre-hass-media-player-cards?color=blue)](https://github.com/antontanderup/mediocre-hass-media-player-cards/releases)
 [![GitHub Downloads (all assets, all releases)](https://img.shields.io/github/downloads/antontanderup/mediocre-hass-media-player-cards/total)](https://github.com/antontanderup/mediocre-hass-media-player-cards/releases)
-[![Chat on Oase](https://img.shields.io/badge/Chat-Oase-lightblue?color=rgb(74%20196%20169))](https://oase.app/oase/8414e128-52fe-42c7-b7c8-789fd0930a3e/join/cfdc211d-eb53-4cef-af62-2d1c4642a180)
+[![Chat on Oase](<https://img.shields.io/badge/Chat-Oase-lightblue?color=rgb(74%20196%20169)>)](https://oase.app/oase/8414e128-52fe-42c7-b7c8-789fd0930a3e/join/cfdc211d-eb53-4cef-af62-2d1c4642a180)
 <br/>
 
 <img src="https://github.com/user-attachments/assets/2ba5d55d-6fd3-4508-ae1c-60d9f22ebe81" width="500px" alt="Mediocre Media Player Card Screenshot 1" />
@@ -86,25 +87,25 @@ speaker_group:
 
 Both cards support these options:
 
-| Option                    | Type   | Default  | Description                                                      |
-| ------------------------- | ------ | -------- | ---------------------------------------------------------------- |
-| `entity_id`               | string | Required | The entity ID of the media player                                |
-| `action`                  | object | -        | Configuration for tap actions                                    |
-| `speaker_group`           | object | -        | Configuration for speaker grouping                               |
-| `speaker_group.entity_id` | string | -        | Entity ID of the main speaker if different from the media player |
-| `speaker_group.entities`  | array  | -        | List of entity IDs that can be grouped with the main speaker     |
-| `custom_buttons`          | array  | -        | List of custom buttons to display                                |
-| `ma_entity_id`            | string | -        | Music Assistant entity id (adds search & queue features)         |
-| `ma_favorite_button_entity_id` | string | - | Music Assistant favorite button entity (shows a heart-plus button to mark the current song as favorite) |
-| `options`                 | object | -        | Additional display options for fine-tuning the card              |
-| `options.always_show_power_button` | boolean | `false` | Always show the power button, even if the media player is on |
+| Option                             | Type    | Default  | Description                                                                                             |
+| ---------------------------------- | ------- | -------- | ------------------------------------------------------------------------------------------------------- |
+| `entity_id`                        | string  | Required | The entity ID of the media player                                                                       |
+| `action`                           | object  | -        | Configuration for tap actions                                                                           |
+| `speaker_group`                    | object  | -        | Configuration for speaker grouping                                                                      |
+| `speaker_group.entity_id`          | string  | -        | Entity ID of the main speaker if different from the media player                                        |
+| `speaker_group.entities`           | array   | -        | List of entity IDs that can be grouped with the main speaker                                            |
+| `custom_buttons`                   | array   | -        | List of custom buttons to display                                                                       |
+| `ma_entity_id`                     | string  | -        | Music Assistant entity id (adds search & queue features)                                                |
+| `ma_favorite_button_entity_id`     | string  | -        | Music Assistant favorite button entity (shows a heart-plus button to mark the current song as favorite) |
+| `options`                          | object  | -        | Additional display options for fine-tuning the card                                                     |
+| `options.always_show_power_button` | boolean | `false`  | Always show the power button, even if the media player is on                                            |
 
 The Mediocre Media Player Card has additional options:
 
-| Option            | Type    | Default | Description                                                            |
-| ----------------- | ------- | ------- | ---------------------------------------------------------------------- |
-| `tap_opens_popup` | boolean | `false` | When set to true, tapping the card opens a popup with the massive card |
-| `options.always_show_custom_buttons` | boolean | `false` | Always show custom buttons panel expanded |
+| Option                               | Type    | Default | Description                                                            |
+| ------------------------------------ | ------- | ------- | ---------------------------------------------------------------------- |
+| `tap_opens_popup`                    | boolean | `false` | When set to true, tapping the card opens a popup with the massive card |
+| `options.always_show_custom_buttons` | boolean | `false` | Always show custom buttons panel expanded                              |
 
 The Mediocre Massive Media Player Card has additional options:
 
@@ -152,7 +153,6 @@ Both the Mediocre Media Player Card and the Mediocre Massive Media Player Card s
 
 ### Configuration
 
-
 ```yaml
 type: "custom:mediocre-media-player-card"
 entity_id: media_player.living_room_musiccast
@@ -194,7 +194,7 @@ Both the Mediocre Media Player Card and the Mediocre Massive Media Player Card s
 
 ## Queue Functionality
 
-When a `ma_entity_id` is specified and `queue.enabled` is set to `true`, the cards can display the current playback queue from Music Assistant. Read more about configuring the cards for queue support [here](./docs/README_QUEUE.md).
+To display the queue, the cards rely on the [`mass_queue`](https://github.com/droans/mass_queue) custom component for Home Assistant. Install this component in your Home Assistant instance before enabling the queue feature. Once installed, and with a `ma_entity_id` specified and `queue.enabled` set to `true`, the cards can show the current playback queue from Music Assistant. Read more about configuring the cards for queue support [here](./docs/README_QUEUE.md).
 
 ## Additional Documentation
 

--- a/docs/README_QUEUE.md
+++ b/docs/README_QUEUE.md
@@ -1,6 +1,6 @@
 # Queue Functionality with Mediocre Media Player Cards
 
-The Mediocre Media Player Cards can display the current playback queue when used with Music Assistant.
+The Mediocre Media Player Cards can display the current playback queue when used with Music Assistant. To enable this feature, first install the [`mass_queue`](https://github.com/droans/mass_queue) custom component for Home Assistant, which exposes Music Assistant's queue to Home Assistant.
 
 ## Configuration Example
 
@@ -20,4 +20,3 @@ queue:
 - `queue.enabled`: Set to `true` to show the current queue in the card.
 
 Once configured, the card will display a queue button that opens the list of upcoming items, similar to the search interface.
-


### PR DESCRIPTION
## Summary
- mention mass_queue Home Assistant custom component requirement in README
- document mass_queue prerequisite in queue functionality guide

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68a6d252e79883218f9eb9411fa54795